### PR TITLE
Fixed pow of return value.

### DIFF
--- a/src/main/java/org/geohex/geohex4j/GeoHex.java
+++ b/src/main/java/org/geohex/geohex4j/GeoHex.java
@@ -159,7 +159,7 @@ public class GeoHex {
         }
 
         for (int i = 0; i <= level + 2; i++) {
-            double h_pow = Math.pow(3, level + 2 - i);
+            double h_pow = Math.round(Math.pow(3, level + 2 - i));
             if (h_decx.get(i) == '0') {
                 h_x -= h_pow;
             } else if (h_decx.get(i) == '2') {


### PR DESCRIPTION
Behavior is different by JVM.

```
// In the case of a JVM,
Math.pow(3, 3); => // 26.99999999999999
Math.pow(3, 1); => // 2.999999999999999

// or
Math.pow(3, 3); => // 27.0
Math.pow(3, 1); => // 3.0
```

So, I was rounded off.