### PR TITLE
Fixed getZoneByXY by round xy.

### DIFF
--- a/src/main/java/org/geohex/geohex4j/GeoHex.java
+++ b/src/main/java/org/geohex/geohex4j/GeoHex.java
@@ -209,20 +209,21 @@ public class GeoHex {
 
         for (int i = 0; i <= level + 2; i++) {
             long h_pow = Math.round(Math.pow(3, level + 2 - i));
-            if (mod_x >= Math.ceil((double) h_pow / 2)) {
+            double h_pow_half = Math.ceil((double) h_pow / 2);
+            if (mod_x >= h_pow_half) {
                 code3_x.add(2);
                 mod_x -= h_pow;
-            } else if (mod_x <= -Math.ceil((double) h_pow / 2)) {
+            } else if (mod_x <= -h_pow_half) {
                 code3_x.add(0);
                 mod_x += h_pow;
             } else {
                 code3_x.add(1);
             }
 
-            if (mod_y >= Math.ceil((double) h_pow / 2)) {
+            if (mod_y >= h_pow_half) {
                 code3_y.add(2);
                 mod_y -= h_pow;
-            } else if (mod_y <= -Math.ceil((double) h_pow / 2)) {
+            } else if (mod_y <= -h_pow_half) {
                 code3_y.add(0);
                 mod_y += h_pow;
             } else {

--- a/src/main/java/org/geohex/geohex4j/GeoHex.java
+++ b/src/main/java/org/geohex/geohex4j/GeoHex.java
@@ -178,8 +178,8 @@ public class GeoHex {
 
     public static final Zone getZoneByXY(double x, double y, int level) {
         double h_size = calcHexSize(level);
-        long h_x = (long) x;
-        long h_y = (long) y;
+        long h_x = Math.round(x);
+        long h_y = Math.round(y);
         double unit_x = 6 * h_size;
         double unit_y = 6 * h_size * h_k;
         double h_lat = (h_k * h_x * unit_x + h_y * unit_y) / 2;
@@ -204,25 +204,25 @@ public class GeoHex {
         List<Integer> code3_y = new ArrayList<Integer>();
         StringBuffer code3 = new StringBuffer();
         StringBuffer code9 = new StringBuffer();
-        long mod_x = (long) h_x;
-        long mod_y = (long) h_y;
+        long mod_x = h_x;
+        long mod_y = h_y;
 
         for (int i = 0; i <= level + 2; i++) {
-            double h_pow = Math.pow(3, level + 2 - i);
-            if (mod_x >= Math.ceil(h_pow / 2)) {
+            long h_pow = Math.round(Math.pow(3, level + 2 - i));
+            if (mod_x >= Math.ceil((double) h_pow / 2)) {
                 code3_x.add(2);
                 mod_x -= h_pow;
-            } else if (mod_x <= -Math.ceil(h_pow / 2)) {
+            } else if (mod_x <= -Math.ceil((double) h_pow / 2)) {
                 code3_x.add(0);
                 mod_x += h_pow;
             } else {
                 code3_x.add(1);
             }
 
-            if (mod_y >= Math.ceil(h_pow / 2)) {
+            if (mod_y >= Math.ceil((double) h_pow / 2)) {
                 code3_y.add(2);
                 mod_y -= h_pow;
-            } else if (mod_y <= -Math.ceil(h_pow / 2)) {
+            } else if (mod_y <= -Math.ceil((double) h_pow / 2)) {
                 code3_y.add(0);
                 mod_y += h_pow;
             } else {


### PR DESCRIPTION
Behavior is different by JVM.
```
// In the case of a JVM,
Math.pow(3, 3); => // 26.99999999999999 (double)

// or
Math.pow(3, 3); => // 27.00000000000001 (double)
```
So, I was rounded off.
```
Math.round(Math.pow(3, 3)); => // 27 (long)
```

This time of change, is only at the time of output.
When at the time of output, to convert XY into "long" is better.
Error does not occur.

==
And, to convert "double" into "long" is cut off after the decimal point.
```
long h_x = (long) x;

// If "x" is 26.99999999999999
// h_x => 26
```
So, I was rounded off.
```
long h_x = Math.round(x);

// If "x" is 26.99999999999999
// h_x => 27
```