### PR TITLE
add equals() and hashCode()

### DIFF
--- a/src/main/java/org/geohex/geohex4j/GeoHex.java
+++ b/src/main/java/org/geohex/geohex4j/GeoHex.java
@@ -2,6 +2,7 @@ package org.geohex.geohex4j;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /*
@@ -66,6 +67,16 @@ public class GeoHex {
                     new Loc(h_btm, h_cr),
                     new Loc(h_btm, h_cl)
             };
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof Zone && this.code.equals(((Zone)other).code);
+        }
+
+        @Override
+        public int hashCode() {
+            return this.code.hashCode();
         }
     }
 
@@ -302,6 +313,18 @@ public class GeoHex {
             this.x = x;
             this.y = y;
         }
+
+        @Override
+        public boolean equals(Object other) {
+            if (!(other instanceof XY)) return false;
+            final XY otherXy = (XY)other;
+            return  this.x == otherXy.x && this.y == otherXy.y;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.x, this.y);
+        }
     }
 
     public static final class Loc {
@@ -310,6 +333,18 @@ public class GeoHex {
         public Loc(double lat, double lon) {
             this.lat = lat;
             this.lon = lon;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (!(other instanceof Loc)) return false;
+            final Loc otherLoc = (Loc)other;
+            return  this.lat == otherLoc.lat && this.lon == otherLoc.lon;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.lat, this.lon);
         }
     }
 

--- a/src/test/java/org/geohex/geohex4j/GeoHexTest.java
+++ b/src/test/java/org/geohex/geohex4j/GeoHexTest.java
@@ -1,13 +1,18 @@
 package org.geohex.geohex4j;
 
-import java.io.*;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
-
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class GeoHexTest {
     private double LOCATION_PRECISION = 0.0000000000001;
@@ -173,6 +178,60 @@ public class GeoHexTest {
             GeoHex.Zone z = GeoHex.getZoneByLocation(lat, lon, level);
             assertEquals(expected_hex_size, z.getHexSize(), LOCATION_PRECISION);
         }
+    }
+
+    @Test
+    public void equalsZone() {
+        GeoHex.Zone zone = GeoHex.getZoneByXY(1, 2, 6);
+        GeoHex.Zone same = GeoHex.getZoneByXY(1, 2, 6);
+        GeoHex.Zone other = GeoHex.getZoneByXY(1, 3, 6);
+        assertTrue(zone.equals(same));
+        assertFalse(zone.equals(other));
+    }
+
+    @Test
+    public void hashCodeZone() {
+        GeoHex.Zone zone = GeoHex.getZoneByXY(1, 2, 6);
+        GeoHex.Zone same = GeoHex.getZoneByXY(1, 2, 6);
+        GeoHex.Zone other = GeoHex.getZoneByXY(1, 3, 6);
+        assertEquals(zone.hashCode(), same.hashCode());
+        assertNotEquals(zone.hashCode(), other.hashCode());
+    }
+
+    @Test
+    public void equalsXY() {
+        GeoHex.XY xy = new GeoHex.XY(1, 1);
+        GeoHex.XY same = new GeoHex.XY(1, 1);
+        GeoHex.XY other = new GeoHex.XY(1, 2);
+        assertTrue(xy.equals(same));
+        assertFalse(xy.equals(other));
+    }
+
+    @Test
+    public void hashCodeXY() {
+        GeoHex.XY xy = new GeoHex.XY(1, 1);
+        GeoHex.XY same = new GeoHex.XY(1, 1);
+        GeoHex.XY other = new GeoHex.XY(1, 2);
+        assertEquals(xy.hashCode(), same.hashCode());
+        assertNotEquals(xy.hashCode(), other.hashCode());
+    }
+
+    @Test
+    public void equalsLoc() {
+        GeoHex.Loc loc = new GeoHex.Loc(1.f, 1.f);
+        GeoHex.Loc same = new GeoHex.Loc(1.f, 1.f);
+        GeoHex.Loc other = new GeoHex.Loc(1.f, 2.f);
+        assertTrue(loc.equals(same));
+        assertFalse(loc.equals(other));
+    }
+
+    @Test
+    public void hashCodeLoc() {
+        GeoHex.Loc loc = new GeoHex.Loc(1.f, 1.f);
+        GeoHex.Loc same = new GeoHex.Loc(1.f, 1.f);
+        GeoHex.Loc other = new GeoHex.Loc(1.f, 2.f);
+        assertEquals(loc.hashCode(), same.hashCode());
+        assertNotEquals(loc.hashCode(), other.hashCode());
     }
 
     private void assertPolygon(double[][] expected_polygon, GeoHex.Loc[] polygon) {


### PR DESCRIPTION
I added `equals()` and `hashCode()` for `Zone`, `XY` and `Loc` classes to compare GeoHex objects.